### PR TITLE
Added `tts_coqui()` and `tts_coqui_voices()`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .Rproj.user
 inst/doc
 .Rhistory
+.DS_Store

--- a/R/aaa_utils.R
+++ b/R/aaa_utils.R
@@ -1,32 +1,51 @@
-tts_audio_read = function(
-  file,
-  output_format = c("mp3", "wav") ) {
+# Read WAV or MP3 files in and store as a Wave object
+tts_audio_read <- function(file,
+                          output_format = c("wav", "mp3")) {
   output_format = match.arg(output_format)
   out = switch(
     output_format,
     wav = tuneR::readWave(file),
-    mp3 = tuneR::readMP3(file),
+    mp3 = tuneR::readMP3(file)
   )
-  return(out)
+  out
 }
+
+# Create temporary audio file (mp3 or wav)
 tts_temp_audio = function(output_format = c("mp3", "wav") ) {
   output_format = match.arg(output_format)
   ext = paste0(".", output_format)
   tempfile(fileext = ext)
 }
-# text = stri_rand_lipsum(5)
-# text = paste(text[1:5], collapse = " ")
 
-tts_split_text = function(text, limit = 5000) {
+# Split text into groups if nchar(text) exceeds limit
+tts_split_text = function(text, limit = 50) {
   stopifnot(is.character(text) & length(text) == 1)
-  nc = nchar(text)
-  if (any(nc > limit)) {
-    pieces <- ceiling(nchar(text)/limit)
+  num_char = nchar(text)
+
+  # If number of characters exceeds the limit,
+  # divide text into groups
+  if (any(num_char > limit)) {
+    # Number of pieces
+    pieces <- ceiling(nchar(text) / limit)
+    # Split text into words
     words <- strsplit(text, " ")[[1]]
-    indices = ceiling(seq_along(words)/(length(words)/pieces))
+
+    indices = ceiling(seq_along(words) / (length(words) / pieces))
+    # Divide words into groups defined by indices
     chunks <- split(words, indices)
+    # Concatenate chunks into a string, separated by a space
     text = vapply(chunks, paste, collapse = " ",
                   FUN.VALUE = character(1))
   }
   return(text)
+}
+
+# Calculate WAV audio duration
+wav_duration = function(object) {
+  if (inherits(object, "Wave")) {
+    l <- length(object@left)
+    return(round(l / object@samp.rate, 2))
+  } else {
+    return(NA_real_)
+  }
 }

--- a/R/tts_amazon_auth.R
+++ b/R/tts_amazon_auth.R
@@ -1,3 +1,5 @@
+#' Authenticate the user's credentials for using the Amazon Polly Text-to-Speech (TTS) service
+#'
 #' @rdname tts_auth
 #' @export
 tts_amazon_auth = function(key_or_json_file = NULL, ...) {

--- a/R/tts_auth.R
+++ b/R/tts_auth.R
@@ -39,7 +39,7 @@ tts_auth = function(service = c("amazon", "google", "microsoft"),
   return(res)
 }
 
-
+#' Check Google Cloud Text-to-Speech API Authentication Status
 #' @rdname tts_auth
 #' @export
 tts_google_authenticated = function() {
@@ -51,7 +51,7 @@ tts_google_authenticated = function() {
   !inherits(res, "try-error")
 }
 
-
+#' Check Amazon Polly Text-to-Speech API Authentication Status
 #' @rdname tts_auth
 #' @export
 tts_amazon_authenticated = function() {
@@ -74,6 +74,8 @@ tts_amazon_authenticated = function() {
   return(TRUE)
 }
 
+
+#' Check Microsoft Cognitive Services Text to Speech REST API Authentication Status
 #' @rdname tts_auth
 #' @export
 tts_microsoft_authenticated = function(...) {

--- a/R/tts_backend.R
+++ b/R/tts_backend.R
@@ -212,12 +212,13 @@ tts_microsoft = function(
 #' @rdname tts
 #' @export
 tts_default_voice = function(
-  service = c("amazon", "google", "microsoft")
+  service = c("amazon", "google", "microsoft", "coqui")
 ) {
   voice = switch(
     service,
     google = "en-US-Standard-C",
     microsoft = "Microsoft Server Speech Text to Speech Voice (en-US, ZiraRUS)",
-    amazon = "Joanna")
+    amazon = "Joanna",
+  # TODO update this  coqui = )
   return(voice)
 }

--- a/R/tts_backend.R
+++ b/R/tts_backend.R
@@ -11,11 +11,11 @@
 #' tts_default_voice("google")
 #' tts_default_voice("microsoft")
 tts_google = function(
-  text,
-  output_format = c("mp3", "wav"),
-  voice = "en-US-Standard-C",
-  bind_audio = TRUE,
-  ...) {
+    text,
+    output_format = c("mp3", "wav"),
+    voice = "en-US-Standard-C",
+    bind_audio = TRUE,
+    ...) {
 
   limit = 5000
   output_format = match.arg(output_format)
@@ -74,11 +74,11 @@ tts_google = function(
 #' </speak>'
 #' }
 tts_amazon = function(
-  text,
-  output_format = c("mp3", "wav"),
-  voice = "Joanna",
-  bind_audio = TRUE,
-  ...) {
+    text,
+    output_format = c("mp3", "wav"),
+    voice = "Joanna",
+    bind_audio = TRUE,
+    ...) {
   if (!requireNamespace("aws.polly", quietly = TRUE)) {
     stop(paste0(
       "This function requires aws.polly to operate",
@@ -106,9 +106,9 @@ tts_amazon = function(
   if (!is.null(args$format)) {
     warning(
       paste0(
-      "format was specified in ... for tts_amazon",
-      ", this should be specified in output_format argument, format",
-      " is overridden")
+        "format was specified in ... for tts_amazon",
+        ", this should be specified in output_format argument, format",
+        " is overridden")
     )
   }
   res = lapply(text, function(string) {
@@ -159,11 +159,11 @@ tts_amazon = function(
 #' @export
 #' @rdname tts
 tts_microsoft = function(
-  text,
-  output_format = c("mp3", "wav"),
-  voice = "Microsoft Server Speech Text to Speech Voice (en-US, ZiraRUS)",
-  bind_audio = TRUE,
-  ...) {
+    text,
+    output_format = c("mp3", "wav"),
+    voice = "Microsoft Server Speech Text to Speech Voice (en-US, ZiraRUS)",
+    bind_audio = TRUE,
+    ...) {
 
   limit = 800
   output_format = match.arg(output_format)
@@ -213,10 +213,80 @@ tts_microsoft = function(
   return(res)
 }
 
+
+tts_coqui <- function(
+    text,
+    # Set Default as WAV and put it in Documentation
+    output_format = c("wav", "mp3"),
+    voice = "tacotron2-DDC",
+    bind_audio = TRUE,
+    ...) {
+  # Is there a max number of limits that coqui TTS takes? (https://github.com/coqui-ai/TTS/discussions/917)
+  limit <- 2500
+  output_format = "wav"
+  audio_type = output_format
+  bind_audio <- TRUE
+  # IF we don't need Linear16, we can delete this switch() chunk
+  output_format = switch(
+    output_format,
+    "wav" = "LINEAR16")
+
+  voice <- "en-US-Standard-C"
+  # In ari::ari_stitch(), where tts_coqui() is called, only WAV is an option for audio file
+  # output_format = match.arg(output_format)
+  text <- c("Good evening, everyone. My name is Howard, and I'm here to talk to you about the exciting world of computer science. Computers have become an integral part of our lives, and the field of computer science is all about understanding how they work and how we can use them to solve real-world problems.
+In this lecture, we'll be covering some of the basics of computer science and what makes it such a fascinating and important field of study.",
+            "First, let's talk about what computer science is. At its core, computer science is all about understanding how computers work and how to use them to solve problems.
+          This includes everything from understanding the basics of programming languages to designing and building complex software systems.",
+            "One of the key concepts in computer science is algorithms. An algorithm is a set of instructions that a computer can follow to solve a problem. Algorithms can be simple or complex, and they're used in everything
+          from sorting data to powering search engines.",
+            "Data structures are the ways in which we organize and store data in a computer. Examples of data structures include arrays, linked lists, and trees.",
+            "Of course, one of the most important aspects of computer science is programming. Programming is the process of writing code that tells a computer what to do.
+          There are many different programming languages out there, from the classic languages like C++ and Java to newer languages like Python and Swift.",
+            "Finally, computer science is a field that's constantly evolving. As technology advances and new problems arise, computer scientists are always developing new tools and techniques to solve them.
+          Whether it's developing new programming languages, creating more efficient algorithms, or designing more powerful hardware, computer science is a field that's always on the cutting edge.")
+
+  res = lapply(text, function(string) {
+    string_processed = tts_split_text(string, limit = limit)
+
+    res = vapply(string_processed, function(tt) {
+      output_path = tts_temp_audio(audio_type)
+      tts_args <- paste0("--text ", shQuote(tt), " ",
+                         "--model_name tts_models/en/ljspeech/tacotron2-DDC_ph --vocoder_name vocoder_models/en/ljspeech/univnet",
+                         " ", "--out_path /private", output_path)
+      # # Run command with temporary system search path
+      res <- withr::with_path("/opt/homebrew/Caskroom/miniforge/base/bin",
+                              system2("tts", tts_args))
+      # Output file path
+      output_path
+    }, FUN.VALUE = character(1L), USE.NAMES = FALSE)
+    out = lapply(res, tts_audio_read,
+                 output_format = audio_type)
+    df = dplyr::tibble(original_text = string,
+                       text = string_processed,
+                       wav = out, file = res)
+  })
+
+  names(res) = seq_along(text)
+  res = dplyr::bind_rows(res, .id = "index")
+  res$index = as.numeric(res$index)
+  res$audio_type = audio_type
+
+  if (bind_audio) {
+    res = tts_bind_wav(res)
+  }
+  if ("wav" %in% colnames(res)) {
+    res$duration = vapply(res$wav, wav_duration, FUN.VALUE = numeric(1))
+  }
+
+
+
+}
+
 #' @rdname tts
 #' @export
 tts_default_voice = function(
-  service = c("amazon", "google", "microsoft", "coqui")
+    service = c("amazon", "google", "microsoft", "coqui")
 ) {
   voice = switch(
     service,

--- a/R/tts_backend.R
+++ b/R/tts_backend.R
@@ -218,7 +218,7 @@ tts_default_voice = function(
     service,
     google = "en-US-Standard-C",
     microsoft = "Microsoft Server Speech Text to Speech Voice (en-US, ZiraRUS)",
-    amazon = "Joanna",
+    amazon = "Joanna")
   # TODO update this  coqui = )
   return(voice)
 }

--- a/R/tts_backend.R
+++ b/R/tts_backend.R
@@ -1,3 +1,4 @@
+#' Convert Text to Speech using Google Cloud Text-to-Speech API
 #' @export
 #' @rdname tts
 #' @param voice A full voice name that can be passed to the
@@ -60,6 +61,7 @@ tts_google = function(
   return(res)
 }
 
+#' Convert Text to Speech using Amazon Polly
 #' @export
 #' @rdname tts
 #' @examples \dontrun{
@@ -152,6 +154,8 @@ tts_amazon = function(
 
 }
 
+
+#' Convert Text to Speech using Microsoft Cognitive Services API
 #' @export
 #' @rdname tts
 tts_microsoft = function(
@@ -218,7 +222,8 @@ tts_default_voice = function(
     service,
     google = "en-US-Standard-C",
     microsoft = "Microsoft Server Speech Text to Speech Voice (en-US, ZiraRUS)",
-    amazon = "Joanna")
-  # TODO update this  coqui = )
-  return(voice)
+    amazon = "Joanna",
+    coqui = "tacotron2-DDC")
+
+  voice
 }

--- a/R/tts_backend.R
+++ b/R/tts_backend.R
@@ -218,34 +218,31 @@ tts_coqui <- function(
     text,
     # Set Default as WAV and put it in Documentation
     output_format = c("wav", "mp3"),
-    voice = "tacotron2-DDC",
+    model_name = "tacotron2-DDC_ph", # CoquiTTS Demo of the different voices: https://huggingface.co/spaces/coqui/CoquiTTS
     bind_audio = TRUE,
     ...) {
   # Is there a max number of limits that coqui TTS takes? (https://github.com/coqui-ai/TTS/discussions/917)
   limit <- 2500
-  output_format = "wav"
+  output_format = match.arg(output_format)
   audio_type = output_format
-  bind_audio <- TRUE
-  # IF we don't need Linear16, we can delete this switch() chunk
-  output_format = switch(
-    output_format,
-    "wav" = "LINEAR16")
+  model_name <- switch(
+    model_name,
+    "tacotron2-DDC_ph" = "tts_models/en/ljspeech/tacotron2-DDC_ph",
+    "vits"             = "tts_models/en/ljspeech/vits",
+    "glow-tts"         = "tts_models/en/ljspeech/glow-tts",
+    "speedy-speech"    = "tts_models/en/ljspeech/speedy-speech",
+    "tacotron2-DCA"    = "tts_models/en/ljspeech/tacotron2-DCA",
+    "tacotron2-DDC"    = "tts_models/en/ljspeech/tacotron2-DDC",
+    "vits--neon"       = "tts_models/en/ljspeech/vits--neon",
+    "fast_pitch"       = "tts_models/en/ljspeech/fast_pitch",
+    "overflow"         = "tts_models/en/ljspeech/overflow",
+    "neural_hmm"       = "tts_models/en/ljspeech/neural_hmm",
+    "tacotron-DDC"     = "tts_models/en/sam/tacotron-DDC",
+    "capacitron-t2-c50"= "tts_models/en/blizzard2013/capacitron-t2-c50",
+    "capacitron-t2-c150_v2" = "tts_models/en/blizzard2013/capacitron-t2-c150_v2"
+  )
 
-  voice <- "en-US-Standard-C"
   # In ari::ari_stitch(), where tts_coqui() is called, only WAV is an option for audio file
-  # output_format = match.arg(output_format)
-  text <- c("Good evening, everyone. My name is Howard, and I'm here to talk to you about the exciting world of computer science. Computers have become an integral part of our lives, and the field of computer science is all about understanding how they work and how we can use them to solve real-world problems.
-In this lecture, we'll be covering some of the basics of computer science and what makes it such a fascinating and important field of study.",
-            "First, let's talk about what computer science is. At its core, computer science is all about understanding how computers work and how to use them to solve problems.
-          This includes everything from understanding the basics of programming languages to designing and building complex software systems.",
-            "One of the key concepts in computer science is algorithms. An algorithm is a set of instructions that a computer can follow to solve a problem. Algorithms can be simple or complex, and they're used in everything
-          from sorting data to powering search engines.",
-            "Data structures are the ways in which we organize and store data in a computer. Examples of data structures include arrays, linked lists, and trees.",
-            "Of course, one of the most important aspects of computer science is programming. Programming is the process of writing code that tells a computer what to do.
-          There are many different programming languages out there, from the classic languages like C++ and Java to newer languages like Python and Swift.",
-            "Finally, computer science is a field that's constantly evolving. As technology advances and new problems arise, computer scientists are always developing new tools and techniques to solve them.
-          Whether it's developing new programming languages, creating more efficient algorithms, or designing more powerful hardware, computer science is a field that's always on the cutting edge.")
-
   res = lapply(text, function(string) {
     string_processed = tts_split_text(string, limit = limit)
 

--- a/R/tts_google_auth.R
+++ b/R/tts_google_auth.R
@@ -1,3 +1,5 @@
+#' Authenticate the user's Google Cloud credentials for using the Google Cloud Text-to-Speech (TTS) API
+
 #' @rdname tts_auth
 #' @export
 tts_google_auth = function(key_or_json_file = NULL, ...) {

--- a/R/tts_microsoft_auth.R
+++ b/R/tts_microsoft_auth.R
@@ -1,3 +1,4 @@
+#' Authenticate the user's credentials for using the Microsoft Cognitive Services Text to Speech REST API,
 #' @rdname tts_auth
 #' @export
 tts_microsoft_auth = function(key_or_json_file = NULL, ...) {

--- a/R/tts_speak_engine.R
+++ b/R/tts_speak_engine.R
@@ -1,5 +1,5 @@
 
-#' Speak Enginge for `knitr`
+#' Speak Engine for `knitr`
 #'
 #' @param options A list of chunk options. Usually this is just the
 #' object options passed to the engine function; see

--- a/R/tts_synthesize.R
+++ b/R/tts_synthesize.R
@@ -1,13 +1,4 @@
-wav_duration = function(object) {
-  if (inherits(object, "Wave")) {
-    l <- length(object@left)
-    return(round(l / object@samp.rate, 2))
-  } else {
-    return(NA_real_)
-  }
-}
-
-#' Text to Speech
+#' Convert Text to Speech
 #'
 #' @param text A character vector of text to speak
 #' @param output_format Format of output files

--- a/R/tts_voices.R
+++ b/R/tts_voices.R
@@ -48,14 +48,15 @@ tts_language_codes = function() {
 #' }
 #' }
 tts_voices = function(
-  service = c("amazon", "google", "microsoft"),
+  service = c("amazon", "google", "microsoft", "coqui"),
   ...
 ) {
   service = match.arg(service)
   res = switch(service,
                amazon = tts_amazon_voices(...),
                google = tts_google_voices(...),
-               microsoft = tts_microsoft_voices(...)
+               microsoft = tts_microsoft_voices(...),
+               coqui = tts_coqui_voices(...),
   )
   res
 }
@@ -140,4 +141,14 @@ tts_google_voices = function(...) {
   res = res[, c("voice", "language", "language_code", "gender")]
   res$service = "google"
   res
+}
+
+#' @rdname tts_voices
+#' @export
+tts_coqui_voices = function(...) {
+  ## CHeck that Coqui is installed 
+  ## Specify options
+  ## Build command
+  ## Run tts command
+  ## Spit out result
 }

--- a/R/tts_voices.R
+++ b/R/tts_voices.R
@@ -48,8 +48,8 @@ tts_language_codes = function() {
 #' }
 #' }
 tts_voices = function(
-  service = c("amazon", "google", "microsoft", "coqui"),
-  ...
+    service = c("amazon", "google", "microsoft", "coqui"),
+    ...
 ) {
   service = match.arg(service)
   res = switch(service,
@@ -145,15 +145,20 @@ tts_google_voices = function(...) {
 
 #' @rdname tts_voices
 #' @export
-tts_coqui_voices = function(...) {
-  ## CHeck that Coqui is installed
-  ## TODO fix the template code below
-  if (!system("which tts-coqui")) {
-  message("ffmpeg not found. Please download and install from https://github.com/coqui-ai/TTS#install-tts")
-  quit(save = "no", status = 1)
+tts_coqui_voices = function(coqui_path) {
+  # Run `which tts` system command with temporary system search path
+  # ignore.stdout: don't print to console
+  check_coqui <- withr::with_path(coqui_path,
+                                  system("which tts", intern = FALSE, ignore.stdout = TRUE))
+  # Check if coqui TTS is installed
+  if (check_coqui > 0) {
+    message("coqui TTS library not found. Please install from https://github.com/coqui-ai/TTS#install-tts")
   }
-  ## Specify options
-  ## Build command
-  ## Run tts command
-  ## Spit out result
+
+  # Run command
+  out <- withr::with_path(coqui_path, system("tts --list_models", intern = TRUE))
+  out <- trimws(out)
+  message("Test out different voices (models) at https://huggingface.co/spaces/coqui/CoquiTTS")
+  # Only show tts_models
+  out[grepl("tts_models", out)]
 }

--- a/R/tts_voices.R
+++ b/R/tts_voices.R
@@ -146,7 +146,12 @@ tts_google_voices = function(...) {
 #' @rdname tts_voices
 #' @export
 tts_coqui_voices = function(...) {
-  ## CHeck that Coqui is installed 
+  ## CHeck that Coqui is installed
+  ## TODO fix the template code below
+  if (!system("which tts-coqui")) {
+  message("ffmpeg not found. Please download and install from https://github.com/coqui-ai/TTS#install-tts")
+  quit(save = "no", status = 1)
+  }
   ## Specify options
   ## Build command
   ## Run tts command

--- a/R/tts_voices.R
+++ b/R/tts_voices.R
@@ -1,3 +1,4 @@
+# Return a data frame of language codes and their corresponding names for text-to-speech services
 tts_language_codes = function() {
   df = data.frame(
     language_code = c("ar-XA", "ar-EG", "ar-SA", "bg-BG", "ca-ES", "cs-CZ",
@@ -27,7 +28,6 @@ tts_language_codes = function() {
 
 #' Text to Speech Voices
 #'
-
 #' @param ... Additional arguments to service voice listings.
 #' @param service service to use
 #'
@@ -61,6 +61,8 @@ tts_voices = function(
   res
 }
 
+
+#' Get Amazon Polly TTS voices
 #' @rdname tts_voices
 #' @export
 tts_amazon_voices = function(...) {
@@ -104,6 +106,7 @@ tts_amazon_voices = function(...) {
   res
 }
 
+#' Get Microsoft Cognitive Services Text to Speech voices
 #' @rdname tts_voices
 #' @export
 tts_microsoft_voices = function(...) {
@@ -121,6 +124,8 @@ tts_microsoft_voices = function(...) {
   res
 }
 
+
+#' Get Google Cloud TTS voices
 #' @rdname tts_voices
 #' @export
 tts_google_voices = function(...) {
@@ -143,6 +148,8 @@ tts_google_voices = function(...) {
   res
 }
 
+
+#' Get Coqui TTS voices (list models)
 #' @rdname tts_voices
 #' @export
 tts_coqui_voices = function(coqui_path) {


### PR DESCRIPTION
1. `tts_coqui_voices()`: Checks if coqui TTS executable is installed in the shell, then runs command `tts --list_models`, and shows all the `tts_models`
2. `tts_coqui()`: Uses the `coqui-ai/TTS` [engine](https://github.com/coqui-ai/TTS) to implement a free version of text-to-speech in the `text2speech` package. Follows format used by `tts_google()`. 
3. Added commented titles to each function in the package.