### PR TITLE
Add vocoder models for Coqui TTS

### DIFF
--- a/R/tts.R
+++ b/R/tts.R
@@ -86,7 +86,6 @@ tts = function(
       exec_path = coqui_path,
       output_format = output_format,
       bind_audio = bind_audio,
-      model_name = voice,
       ...)
   }
   res$service = service

--- a/R/tts.R
+++ b/R/tts.R
@@ -86,6 +86,7 @@ tts = function(
       exec_path = coqui_path,
       output_format = output_format,
       bind_audio = bind_audio,
+      model_name = voice,
       ...)
   }
   res$service = service

--- a/R/tts_voices.R
+++ b/R/tts_voices.R
@@ -200,17 +200,19 @@ tts_coqui_voices = function() {
   out <- withr::with_path(process_coqui_path(coqui_path),
                           system("tts --list_models", intern = TRUE))
   out <- trimws(out)
-  # Format the output into a dataframe with 3 columns: language, dataset, voice
-  out <- out[grepl("tts_models", out)]
+  # Grab tts_models and vocoder_models
+  out <- out[grepl("tts_models|vocoder_models", out)]
   # Extract out everything after [number]:
-  out <- sub("^.*tts_models/", "", out)
+  out <- sub("^\\d+:\\s*", "", out)
+  # Remove [already downloaded]
+  out <- gsub("\\s*\\[already downloaded\\]", "", out)
   out <- data.frame(out)
 
   # Separate by "//" using tidyr::separate()
   out <- out %>%
     tidyr::separate_wider_delim(out,
                                 delim = "/",
-                                names = c("language", "dataset", "model_name")) %>%
+                                names = c("type", "language", "dataset", "model_name")) %>%
     dplyr::mutate(service = "coqui")
 
   cli::cli_alert_info("Test out different voices on the {.href [CoquiTTS Demo](https://huggingface.co/spaces/coqui/CoquiTTS)}")

--- a/tests/testthat/test-tts_voices.R
+++ b/tests/testthat/test-tts_voices.R
@@ -13,7 +13,7 @@ patrick::with_parameters_test_that("test tts_voices() on Amazon, Google, and Mic
                                    company  = c("amazon", "google", "microsoft")
 )
 
-fixed_names_coqui <- c("language", "dataset", "model_name", "service")
+fixed_names_coqui <- c("type", "language", "dataset", "model_name", "service")
 
 test_that("test tts_voices() on Coqui engine",
           {


### PR DESCRIPTION
I added vocoder models to the output of `tts_voices(service = "coqui")`

Inside `tts_coqui_voices()`:
- Grab `tts_models` and `vocoder_models` from output
- Remove `[already downloaded]` 
- Add `type` as a column to the final output dataset 